### PR TITLE
Feature4: 카카오페이 간편결제 시스템 구현

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
 import { Providers } from "./providers";
 
@@ -17,6 +18,13 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
+      <head>
+        {/* PortOne SDK - 카카오페이 결제용 */}
+        <Script
+          src="https://cdn.iamport.kr/v1/iamport.js"
+          strategy="beforeInteractive"
+        />
+      </head>
       <body className={inter.className}>
         <Providers>{children}</Providers>
       </body>

--- a/lib/portone.ts
+++ b/lib/portone.ts
@@ -1,19 +1,17 @@
 /**
  * PortOne 결제 유틸리티
- * 실제 결제 연동 시 @portone/browser-sdk/v2 사용
+ * 카카오페이 간편결제 연동
  */
 
-// import * as PortOne from '@portone/browser-sdk/v2';
-
 const STORE_ID = process.env.NEXT_PUBLIC_PORTONE_STORE_ID || 'imp12345678';
-const CHANNEL_KEY = process.env.NEXT_PUBLIC_PORTONE_CHANNEL_KEY || 'channel-key-1234';
 
-export interface PaymentRequest {
-  orderName: string;
-  amount: number;
-  orderUid: string;
-  buyerName?: string;
-  buyerEmail?: string;
+declare global {
+  interface Window {
+    IMP?: {
+      init: (storeId: string) => void;
+      request_pay: (params: any, callback: (response: any) => void) => void;
+    };
+  }
 }
 
 export interface PaymentResult {
@@ -23,81 +21,50 @@ export interface PaymentResult {
 }
 
 /**
- * 일반 결제 요청 (일회성 결제)
+ * 카카오페이 결제 수단 등록 (0원 결제)
  */
-export async function requestPayment(request: PaymentRequest): Promise<PaymentResult> {
-  try {
-    // Mock: 실제 PortOne 연동 시 주석 해제
-    // const response = await PortOne.requestPayment({
-    //   storeId: STORE_ID,
-    //   channelKey: CHANNEL_KEY,
-    //   paymentId: request.orderUid,
-    //   orderName: request.orderName,
-    //   totalAmount: request.amount,
-    //   currency: 'CURRENCY_KRW',
-    //   payMethod: 'CARD',
-    //   customer: {
-    //     fullName: request.buyerName,
-    //     email: request.buyerEmail,
-    //   },
-    // });
-
-    // Mock 응답 (테스트용)
-    console.log('[PortOne Mock] Payment requested:', request);
-    return {
-      success: true,
-      impUid: `billing_mock_${Date.now()}`,
-    };
-  } catch (error) {
-    console.error('Payment error:', error);
-    return {
-      success: false,
-      errorMsg: '결제 중 오류가 발생했습니다.',
-    };
-  }
-}
-
-/**
- * 정기 결제 등록 (빌링키 발급)
- */
-export async function issueBillingKey(
+export async function registerPaymentMethod(
   customerUid: string,
-  buyerName?: string,
-  buyerEmail?: string
+  buyerName: string,
+  buyerEmail: string
 ): Promise<PaymentResult> {
-  try {
-    // Mock: 실제 PortOne 연동 시 주석 해제
-    // const response = await PortOne.requestIssueBillingKey({
-    //   storeId: STORE_ID,
-    //   channelKey: CHANNEL_KEY,
-    //   billingKeyMethod: 'CARD',
-    //   customer: {
-    //     customerId: customerUid,
-    //     fullName: buyerName,
-    //     email: buyerEmail,
-    //   },
-    //   issueId: `BILLING-${Date.now()}`,
-    //   issueName: '정기 결제 등록',
-    // });
+  return new Promise((resolve) => {
+    if (typeof window === 'undefined' || !window.IMP) {
+      resolve({
+        success: false,
+        errorMsg: 'PortOne SDK가 로드되지 않았습니다.',
+      });
+      return;
+    }
 
-    // Mock 응답 (테스트용)
-    console.log('[PortOne Mock] Billing key issued:', { customerUid, buyerName, buyerEmail });
-    return {
-      success: true,
-      impUid: `billing_mock_${Date.now()}`,
-    };
-  } catch (error) {
-    console.error('Billing key error:', error);
-    return {
-      success: false,
-      errorMsg: '결제 수단 등록 중 오류가 발생했습니다.',
-    };
-  }
-}
+    window.IMP.init(STORE_ID);
 
-/**
- * 주문 번호 생성
- */
-export function generateOrderUid(prefix: string = 'ORDER'): string {
-  return `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+    window.IMP.request_pay(
+      {
+        pg: 'kakaopay',
+        pay_method: 'card',
+        merchant_uid: `billing_${Date.now()}`,
+        name: '카카오페이 결제 수단 등록',
+        amount: 0,
+        buyer_email: buyerEmail,
+        buyer_name: buyerName,
+        customer_uid: customerUid,
+      },
+      (response: any) => {
+        console.log('[PortOne] 카카오페이 응답:', response);
+
+        if (response.success) {
+          resolve({
+            success: true,
+            impUid: response.imp_uid,
+          });
+        } else {
+          resolve({
+            success: false,
+            errorMsg: response.error_msg || '결제 수단 등록에 실패했습니다.',
+          });
+        }
+      }
+    );
+  });
 }


### PR DESCRIPTION
## 개요
카드 입력 폼을 제거하고 카카오페이 0원 결제를 통한 결제 수단 등록으로 전환함. PortOne SDK를 통해 간편하고 안전한 빌링키 발급 플로우를 구현함.

## 변경 사항
* PortOne SDK 로드 (`app/layout.tsx`)
* 카카오페이 0원 결제로 결제 수단 등록 구현 (`lib/portone.ts`)
* 카드 입력 폼 제거 및 카카오페이 버튼으로 UI 변경 (`SubscriptionPayment.tsx`)
* 불필요한 카드 관련 함수 및 state 제거, 코드 간소화

## 배포
* 프리뷰 배포 성공 (Vercel)
* 실제 배포 시 PortOne 상점 ID 및 카카오페이 설정 확인 필요

## 참고
* 결제 수단 등록은 카카오페이로만 진행
* 0원 결제로 사용자 부담 없이 빌링키 발급 가능
* 향후 다른 간편결제 수단 추가 가능한 구조