### PR TITLE
Feature/4: PortOne Store ID 하드코딩 제거

### DIFF
--- a/lib/portone.ts
+++ b/lib/portone.ts
@@ -3,7 +3,7 @@
  * 카카오페이 간편결제 연동
  */
 
-const STORE_ID = process.env.NEXT_PUBLIC_PORTONE_STORE_ID || 'imp12345678';
+const STORE_ID = process.env.NEXT_PUBLIC_PORTONE_STORE_ID!;
 
 declare global {
   interface Window {


### PR DESCRIPTION
# [Fix] PortOne Store ID 하드코딩 제거

## 개요
소스 코드에 하드코딩되어 있던 PortOne Store ID fallback 값을 제거함. 환경변수만 사용하도록 개선하여 보안을 강화함.

## 변경 사항
* PortOne Store ID fallback 값 제거
* 환경변수 미설정 시 명확한 에러 처리 추가

## 배포
* `NEXT_PUBLIC_PORTONE_STORE_ID` 환경변수 필수 설정 확인 필요
* 프리뷰/프로덕션 환경에서 환경변수 설정 검증

## 참고
* 하드코딩된 Store ID 노출 방지
* 환경별 Store ID 관리 용이