### PR TITLE
Feature/6: GCP 계정 정보 업데이트 - 사용자 입력 계정 이름 및 ID 형식 개선

### DIFF
--- a/components/mypage/CloudAccountConnection.tsx
+++ b/components/mypage/CloudAccountConnection.tsx
@@ -49,8 +49,8 @@ export function CloudAccountConnection() {
       (gcpAccounts || []).map((g: GcpAccount) => ({
         id: String(g.id),
         provider: 'GCP',
-        accountName: g.serviceAccountName,
-        accountId: g.projectId,
+        accountName: g.name || g.serviceAccountName, // 사용자가 입력한 계정 이름, 없으면 serviceAccountName 사용
+        accountId: `${g.serviceAccountName}@${g.projectId}`, // serviceaccountname@projectid 형식
         status: 'connected' as const,
         lastSync: g.createdAt || new Date().toISOString(),
         monthlyCost: 0,

--- a/lib/api/gcp.ts
+++ b/lib/api/gcp.ts
@@ -2,6 +2,7 @@ import { api } from './client';
 
 export interface GcpAccount {
   id: number;
+  name?: string; // 사용자가 연동 시 입력한 계정 이름
   serviceAccountName: string;
   projectId: string;
   createdAt: string;


### PR DESCRIPTION
## 개요
GCP 계정 목록에서 사용자가 입력한 계정 이름을 우선 표시하고, 계정 ID를 `serviceAccountName@projectId` 형식으로 개선하여 가독성을 향상함.

## 변경 사항
* GcpAccount 인터페이스에 `name` 필드 추가 (사용자 입력 계정 이름)
* `accountName` 표시 로직 개선: 사용자 입력 이름 우선, 없으면 serviceAccountName 사용
* `accountId` 형식 변경: `projectId` → `serviceAccountName@projectId`

## 배포
* 프리뷰 배포 성공 (Vercel)
* 기존 연동된 GCP 계정도 새 형식으로 표시됨

## 참고
* 사용자 친화적인 계정 이름 표시로 UX 개선
* 이메일 형식의 계정 ID로 식별 용이
* AWS 계정과 표시 방식 일관성 유지
