### PR TITLE
Feature/6: GCP 계정 저장 시 name 추가

### DIFF
--- a/components/mypage/AddCloudAccountDialog.tsx
+++ b/components/mypage/AddCloudAccountDialog.tsx
@@ -136,6 +136,7 @@ export function AddCloudAccountDialog({ open, onOpenChange, userName = '사용�
         }
 
         const saveResult = await saveGcpIntegration({
+          name: credentials.accountName.trim(), // 사용자가 입력한 계정 이름 전송
           serviceAccountId: credentials.serviceAccountId.trim(),
           serviceAccountKeyJson: credentials.jsonKeyContent,
           billingAccountId: credentials.billingAccountId.trim(),

--- a/lib/api/gcp.ts
+++ b/lib/api/gcp.ts
@@ -38,6 +38,7 @@ export interface TestIntegrationResponse {
 }
 
 export interface SaveIntegrationRequest {
+  name?: string; // 사용자가 입력한 계정 이름
   serviceAccountId: string;
   serviceAccountKeyJson: string;
   billingAccountId?: string;


### PR DESCRIPTION
## 개요
GCP 계정 연동 시 사용자가 입력한 계정 이름을 백엔드로 전송하여 저장하도록 개선함. 향후 계정 목록 조회 시 사용자 지정 이름으로 표시됨.

## 변경 사항
* `SaveIntegrationRequest` 인터페이스에 `name` 필드 추가 (optional)
* `saveGcpIntegration()` 호출 시 사용자 입력 계정 이름 전송
* 계정 이름 trim 처리로 공백 제거

## 배포
* 프리뷰 배포 성공 (Vercel)
* 백엔드 API에서 name 필드 저장 지원 확인 필요

## 참고
* 기존 연동된 계정은 name이 없으므로 serviceAccountName으로 표시
* 신규 연동 시 사용자 지정 이름 저장 및 표시
* #14 (GCP 계정 정보 표시 개선)과 연계된 작업
