### PR TITLE
Feature/13: GCP 리소스 상세 정보 표시 기능 추가 및 리소스 카드 업데이트

### DIFF
--- a/components/resources/ResourceManagementSection.tsx
+++ b/components/resources/ResourceManagementSection.tsx
@@ -40,7 +40,7 @@ function formatDate(iso: string): string {
 function getServiceIcon(service: string) {
   switch (service) {
     case 'EC2':
-    case 'Compute Engine':
+    case 'Instance':
     case 'Virtual Machines':
       return Server;
     default:
@@ -338,6 +338,11 @@ export function ResourceManagementSection() {
                             {isEc2 && (
                               <div className="text-xs text-slate-500 font-mono mt-1">
                                 {ec2Instance.instanceId}
+                              </div>
+                            )}
+                            {resource.provider === 'GCP' && resource.service === 'Instance' && (
+                              <div className="text-xs text-slate-500 font-mono mt-1">
+                                {resource.id}
                               </div>
                             )}
                           </div>


### PR DESCRIPTION
## 개요
GCP Compute Engine 인스턴스의 상세 정보를 리소스 카드에 표시하도록 개선함. EC2와 동일한 수준의 정보를 제공하여 일관된 사용자 경험을 제공함.

## 변경 사항
* GCP 리소스 Map 생성 로직 추가 (resourceId 기반 인덱싱)
* ResourceCard 컴포넌트에 `gcpResource` prop 추가
* GCP Instance 상세 정보 표시
  - 인스턴스 타입 (machineType)
  - 퍼블릭/프라이빗 IP
  - 가용 영역
  - 업데이트 시간
* 리소스 카드 레이아웃 분기 개선 (EC2, GCP Instance, 기타)
* ResourceManagementSection에 GCP Instance resourceId 표시
* 서비스 아이콘 매핑 개선 (`Compute Engine` → `Instance`)

## 배포
* 프리뷰 배포 성공 (Vercel)
* GCP Instance 상세 정보 표시 확인 완료

## 참고
* 2개 파일 변경 (ResourceExplorer, ResourceManagementSection)
* GCP 리소스의 additionalAttributes에서 인스턴스 메타데이터 파싱
* EC2와 동일한 정보 구조로 멀티 클라우드 일관성 확보
* 향후 다른 GCP 리소스 타입도 동일한 패턴으로 확장 가능