### PR TITLE
feat: 마이페이지 설정 개선 및 Question Unit 시스템 도입

### DIFF
--- a/components/ai/AIChatPanel.tsx
+++ b/components/ai/AIChatPanel.tsx
@@ -150,7 +150,7 @@ export function AIChatPanel() {
   return (
     <div
       className={cn(
-        'fixed right-0 top-0 h-full w-96 bg-white shadow-2xl z-50 flex flex-col',
+        'fixed right-0 top-0 h-full w-[480px] bg-white shadow-2xl z-50 flex flex-col',
         TRANSITION_CLASS,
         aiChatOpen ? 'translate-x-0' : 'translate-x-full'
       )}

--- a/components/layout/MainLayout.tsx
+++ b/components/layout/MainLayout.tsx
@@ -27,7 +27,7 @@ export function MainLayout({ children, showTopbar = true }: MainLayoutProps) {
         <div className={cn(
           'flex-1 flex flex-col overflow-hidden ml-16',
           TRANSITION_CLASS,
-          aiChatOpen ? 'mr-96' : 'mr-0'
+          aiChatOpen ? 'mr-[480px]' : 'mr-0'
         )}>
           {showTopbar && <Topbar />}
           <main className="flex-1 overflow-auto p-4 md:p-6 bg-gray-50">

--- a/components/mypage/PurchaseQuestionUnitDialog.tsx
+++ b/components/mypage/PurchaseQuestionUnitDialog.tsx
@@ -6,14 +6,14 @@ import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
-interface PurchaseTokenDialogProps {
+interface PurchaseQuestionUnitDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onPurchase?: (packageId: string, amount: number, price: number) => void;
   isLoading?: boolean;
 }
 
-interface TokenPackage {
+interface QuestionUnitPackage {
   id: string;
   amount: number;
   price: number;
@@ -21,39 +21,39 @@ interface TokenPackage {
   popular?: boolean;
 }
 
-const TOKEN_PACKAGES: TokenPackage[] = [
+const QUESTION_UNIT_PACKAGES: QuestionUnitPackage[] = [
   {
     id: 'small',
-    amount: 100,
-    price: 5000,
+    amount: 30,
+    price: 4000,
   },
   {
     id: 'medium',
-    amount: 500,
-    price: 20000,
-    bonus: 50,
+    amount: 50,
+    price: 6000,
+    bonus: 10,
     popular: true,
   },
   {
     id: 'large',
-    amount: 1000,
-    price: 35000,
-    bonus: 150,
+    amount: 100,
+    price: 8000,
+    bonus: 20,
   },
 ];
 
-export function PurchaseTokenDialog({
+export function PurchaseQuestionUnitDialog({
   open,
   onOpenChange,
   onPurchase,
   isLoading = false,
-}: PurchaseTokenDialogProps) {
+}: PurchaseQuestionUnitDialogProps) {
   const [selectedPackage, setSelectedPackage] = useState<string | null>(null);
 
   const handlePurchase = () => {
-    const pkg = TOKEN_PACKAGES.find((p) => p.id === selectedPackage);
+    const pkg = QUESTION_UNIT_PACKAGES.find((p) => p.id === selectedPackage);
     if (pkg) {
-      // 백엔드는 기본 토큰 수량만 검증 (보너스 제외)
+      // 백엔드는 기본 Question Unit 수량만 검증 (보너스 제외)
       onPurchase?.(pkg.id, pkg.amount, pkg.price);
     }
   };
@@ -65,15 +65,15 @@ export function PurchaseTokenDialog({
           <div className="absolute inset-0 bg-white/80 backdrop-blur-sm z-50 flex items-center justify-center rounded-lg">
             <div className="flex flex-col items-center gap-3">
               <Loader2 className="h-10 w-10 text-amber-600 animate-spin" />
-              <p className="text-sm font-medium text-gray-700">토큰 구매 중...</p>
+              <p className="text-sm font-medium text-gray-700">Question Unit 구매 중...</p>
             </div>
           </div>
         )}
         {/* 헤더 */}
         <div className="flex items-center justify-between p-6 border-b border-gray-200">
           <div>
-            <h2 className="text-2xl font-bold text-gray-900">토큰 구매</h2>
-            <p className="text-gray-600 mt-1">필요한 토큰 패키지를 선택하세요</p>
+            <h2 className="text-2xl font-bold text-gray-900">Question Unit 구매</h2>
+            <p className="text-gray-600 mt-1">필요한 Question Unit 패키지를 선택하세요</p>
           </div>
           <button
             onClick={() => onOpenChange(false)}
@@ -87,7 +87,7 @@ export function PurchaseTokenDialog({
         {/* 본문 */}
         <div className="p-6">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-            {TOKEN_PACKAGES.map((pkg) => (
+            {QUESTION_UNIT_PACKAGES.map((pkg) => (
               <button
                 key={pkg.id}
                 onClick={() => setSelectedPackage(pkg.id)}
@@ -130,7 +130,7 @@ export function PurchaseTokenDialog({
                       ₩{pkg.price.toLocaleString()}
                     </p>
                     <p className="text-xs text-gray-500 mt-1">
-                      토큰당 ₩{Math.round(pkg.price / (pkg.amount + (pkg.bonus || 0)))}
+                      Unit당 ₩{Math.round(pkg.price / (pkg.amount + (pkg.bonus || 0)))}
                     </p>
                   </div>
                 </div>
@@ -144,11 +144,11 @@ export function PurchaseTokenDialog({
               <span className="text-xs text-gray-600">i</span>
             </div>
             <div className="text-sm text-gray-600">
-              <p className="font-medium mb-1">토큰 사용 안내</p>
+              <p className="font-medium mb-1">Question Unit 사용 안내</p>
               <ul className="space-y-1 text-xs">
-                <li>• 구매한 토큰은 즉시 계정에 추가됩니다</li>
-                <li>• 토큰은 월간 할당량과 별도로 사용됩니다</li>
-                <li>• 구매한 토큰은 만료되지 않습니다</li>
+                <li>• 구매한 Question Unit은 즉시 계정에 추가됩니다</li>
+                <li>• Question Unit은 월간 할당량과 별도로 사용됩니다</li>
+                <li>• 구매한 Question Unit은 만료되지 않습니다</li>
               </ul>
             </div>
           </div>

--- a/components/mypage/Settings.tsx
+++ b/components/mypage/Settings.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { Bell, Mail, Globe, Shield, Moon, Database } from 'lucide-react';
+import { Bell, Globe, Shield, Moon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Toggle } from '@/components/ui/toggle';
@@ -12,13 +12,7 @@ export function Settings() {
     notifications: {
       budgetAlerts: true,
       anomalyDetection: true,
-      weeklyReport: true,
-      monthlyReport: false,
-    },
-    email: {
-      marketing: false,
-      productUpdates: true,
-      securityAlerts: true,
+      slackNotifications: true,
     },
     preferences: {
       language: 'ko',
@@ -109,70 +103,12 @@ export function Settings() {
 
             <div className="flex items-center justify-between">
               <div>
-                <p className="font-medium text-gray-900">주간 리포트</p>
-                <p className="text-sm text-gray-600">매주 비용 요약 리포트</p>
+                <p className="font-medium text-gray-900">Slack 알림</p>
+                <p className="text-sm text-gray-600">리소스 상태 및 임계값 초과 시 Slack으로 알림 전송</p>
               </div>
               <Toggle
-                checked={settings.notifications.weeklyReport}
-                onChange={() => handleToggle('notifications', 'weeklyReport')}
-              />
-            </div>
-
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="font-medium text-gray-900">월간 리포트</p>
-                <p className="text-sm text-gray-600">매월 상세 비용 리포트</p>
-              </div>
-              <Toggle
-                checked={settings.notifications.monthlyReport}
-                onChange={() => handleToggle('notifications', 'monthlyReport')}
-              />
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* 이메일 설정 */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Mail className="h-5 w-5 text-gray-700" />
-              이메일 설정
-            </CardTitle>
-            <CardDescription>
-              이메일 수신 설정을 관리합니다
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="font-medium text-gray-900">마케팅 이메일</p>
-                <p className="text-sm text-gray-600">프로모션 및 뉴스레터</p>
-              </div>
-              <Toggle
-                checked={settings.email.marketing}
-                onChange={() => handleToggle('email', 'marketing')}
-              />
-            </div>
-
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="font-medium text-gray-900">제품 업데이트</p>
-                <p className="text-sm text-gray-600">새로운 기능 및 개선사항</p>
-              </div>
-              <Toggle
-                checked={settings.email.productUpdates}
-                onChange={() => handleToggle('email', 'productUpdates')}
-              />
-            </div>
-
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="font-medium text-gray-900">보안 알림</p>
-                <p className="text-sm text-gray-600">계정 보안 관련 중요 알림</p>
-              </div>
-              <Toggle
-                checked={settings.email.securityAlerts}
-                onChange={() => handleToggle('email', 'securityAlerts')}
+                checked={settings.notifications.slackNotifications}
+                onChange={() => handleToggle('notifications', 'slackNotifications')}
               />
             </div>
           </CardContent>
@@ -308,40 +244,6 @@ export function Settings() {
                 className="border-gray-300 text-gray-700"
               >
                 비밀번호 변경
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* 데이터 관리 */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Database className="h-5 w-5 text-gray-700" />
-              데이터 관리
-            </CardTitle>
-            <CardDescription>
-              데이터 내보내기 및 삭제를 관리합니다
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
-              <div>
-                <p className="font-medium text-gray-900">데이터 내보내기</p>
-                <p className="text-sm text-gray-600">모든 데이터를 다운로드</p>
-              </div>
-              <Button variant="outline" className="border-gray-300 text-gray-700">
-                내보내기
-              </Button>
-            </div>
-
-            <div className="flex items-center justify-between p-4 bg-red-50 rounded-lg border border-red-200">
-              <div>
-                <p className="font-medium text-red-900">모든 데이터 삭제</p>
-                <p className="text-sm text-red-600">이 작업은 되돌릴 수 없습니다</p>
-              </div>
-              <Button variant="outline" className="border-red-300 text-red-600 hover:bg-red-100">
-                삭제
               </Button>
             </div>
           </CardContent>

--- a/components/mypage/SubscriptionPayment.tsx
+++ b/components/mypage/SubscriptionPayment.tsx
@@ -18,13 +18,13 @@ import {
 } from '@/lib/api/subscription';
 import { SUBSCRIPTION_PLANS, PAYMENT_STATUS_CONFIG } from '@/constants/mypage';
 import { type SubscriptionPlan } from '@/types/mypage';
-import { PurchaseTokenDialog } from './PurchaseTokenDialog';
+import { PurchaseQuestionUnitDialog } from './PurchaseQuestionUnitDialog';
 import { registerPaymentMethod, requestPayment, generateOrderUid } from '@/lib/portone';
 import { api } from '@/lib/api/client';
 import { TEMP_USER_ID, TEST_USER, PAYMENT_ERRORS, PAYMENT_SUCCESS } from '@/lib/constants/payment';
 
 // 상수
-const DEFAULT_TOKEN_VALUES = {
+const DEFAULT_QUESTION_UNIT_VALUES = {
   current: 80,
   max: 100,
   resetDate: '2025.11.01',
@@ -93,23 +93,23 @@ function CurrentSubscriptionCard({
   );
 }
 
-// 서브 컴포넌트: 토큰 현황 카드
-function TokenStatusCard({
-  currentTokens,
-  maxTokens,
-  tokenResetDate,
+// 서브 컴포넌트: Question Unit 현황 카드
+function QuestionUnitStatusCard({
+  currentQuestionUnits,
+  maxQuestionUnits,
+  questionUnitResetDate,
   isPro,
   onPurchaseClick,
 }: {
-  currentTokens: number;
-  maxTokens: number;
-  tokenResetDate: string;
+  currentQuestionUnits: number;
+  maxQuestionUnits: number;
+  questionUnitResetDate: string;
   isPro: boolean;
   onPurchaseClick?: () => void;
 }) {
-  const tokenPercentage = useMemo(
-    () => (currentTokens / maxTokens) * 100,
-    [currentTokens, maxTokens]
+  const questionUnitPercentage = useMemo(
+    () => (currentQuestionUnits / maxQuestionUnits) * 100,
+    [currentQuestionUnits, maxQuestionUnits]
   );
 
   return (
@@ -118,22 +118,22 @@ function TokenStatusCard({
         <div className="flex items-center justify-between">
           <CardTitle className="flex items-center gap-2">
             <Zap className="h-5 w-5 text-amber-600" />
-            <span>토큰 현황</span>
+            <span>Question Unit 현황</span>
           </CardTitle>
-          <span className="text-sm text-gray-600">{tokenResetDate} 리셋</span>
+          <span className="text-sm text-gray-600">{questionUnitResetDate} 리셋</span>
         </div>
       </CardHeader>
       <CardContent>
         <div className="flex items-center justify-between">
           <div>
             <div className="flex items-baseline gap-2 mb-1">
-              <h3 className="text-2xl font-bold text-gray-900">{currentTokens}</h3>
-              <span className="text-gray-600">/ {maxTokens}</span>
+              <h3 className="text-2xl font-bold text-gray-900">{currentQuestionUnits}</h3>
+              <span className="text-gray-600">/ {maxQuestionUnits}</span>
             </div>
             <div className="w-64 bg-gray-200 rounded-full h-2 overflow-hidden mt-2">
               <div
                 className="bg-amber-500 h-full rounded-full transition-all duration-300"
-                style={{ width: `${tokenPercentage}%` }}
+                style={{ width: `${questionUnitPercentage}%` }}
               />
             </div>
           </div>
@@ -147,7 +147,7 @@ function TokenStatusCard({
                   : 'bg-gray-200 text-gray-400 cursor-not-allowed'
               )}
             >
-              토큰 추가 구매
+              Question Unit 추가 구매
             </Button>
             {!isPro && (
               <p className="text-xs text-gray-600 text-center">
@@ -312,20 +312,20 @@ export function SubscriptionPayment() {
     queryFn: getPaymentHistory,
   });
 
-  // 토큰 정보 (임시 데이터, 나중에 API로 교체)
-  const tokenInfo = useMemo(
+  // Question Unit 정보 (임시 데이터, 나중에 API로 교체)
+  const questionUnitInfo = useMemo(
     () => ({
-      current: subscription?.currentTokens ?? DEFAULT_TOKEN_VALUES.current,
-      max: subscription?.maxTokens ?? DEFAULT_TOKEN_VALUES.max,
-      resetDate: subscription?.tokenResetDate ?? DEFAULT_TOKEN_VALUES.resetDate,
+      current: subscription?.currentTokens ?? DEFAULT_QUESTION_UNIT_VALUES.current,
+      max: subscription?.maxTokens ?? DEFAULT_QUESTION_UNIT_VALUES.max,
+      resetDate: subscription?.tokenResetDate ?? DEFAULT_QUESTION_UNIT_VALUES.resetDate,
       isPro: subscription?.planId === 'pro',
     }),
     [subscription]
   );
 
-  const handleTokenPurchase = () => {
-    if (tokenInfo.isPro) {
-      // Pro 플랜 - 토큰 구매 다이얼로그 표시
+  const handleQuestionUnitPurchase = () => {
+    if (questionUnitInfo.isPro) {
+      // Pro 플랜 - Question Unit 구매 다이얼로그 표시
       setShowPurchaseDialog(true);
     }
     // Free 플랜일 때는 버튼이 disabled이므로 이 함수가 호출되지 않음
@@ -441,7 +441,7 @@ export function SubscriptionPayment() {
   };
 
   /**
-   * 토큰 구매 핸들러 - 빌링키 자동결제
+   * Question Unit 구매 핸들러 - 빌링키 자동결제
    */
   const handlePurchase = async (packageId: string, amount: number, price: number) => {
     try {
@@ -454,7 +454,7 @@ export function SubscriptionPayment() {
         return;
       }
 
-      // 백엔드에 토큰 구매 요청 (빌링키로 자동결제)
+      // 백엔드에 Question Unit 구매 요청 (빌링키로 자동결제)
       await api.post(`/v1/users/${TEMP_USER_ID}/payment/purchase-tokens`, {
         packageId,
         amount,
@@ -468,7 +468,7 @@ export function SubscriptionPayment() {
       setShowPurchaseDialog(false);
       alert(PAYMENT_SUCCESS.TOKEN_PURCHASED(amount));
     } catch (error) {
-      console.error('Token purchase error:', error);
+      console.error('Question Unit purchase error:', error);
       alert(PAYMENT_ERRORS.TOKEN_PURCHASE_FAILED);
     } finally {
       setIsLoadingPurchase(false);
@@ -484,12 +484,12 @@ export function SubscriptionPayment() {
 
       <CurrentSubscriptionCard subscription={subscription} onChangePlan={() => setShowPlans(true)} />
 
-      <TokenStatusCard
-        currentTokens={tokenInfo.current}
-        maxTokens={tokenInfo.max}
-        tokenResetDate={tokenInfo.resetDate}
-        isPro={tokenInfo.isPro}
-        onPurchaseClick={handleTokenPurchase}
+      <QuestionUnitStatusCard
+        currentQuestionUnits={questionUnitInfo.current}
+        maxQuestionUnits={questionUnitInfo.max}
+        questionUnitResetDate={questionUnitInfo.resetDate}
+        isPro={questionUnitInfo.isPro}
+        onPurchaseClick={handleQuestionUnitPurchase}
       />
 
       <PlanChangeDialog
@@ -500,7 +500,7 @@ export function SubscriptionPayment() {
         isLoading={isLoadingPlan}
       />
 
-      <PurchaseTokenDialog
+      <PurchaseQuestionUnitDialog
         open={showPurchaseDialog}
         onOpenChange={setShowPurchaseDialog}
         onPurchase={handlePurchase}

--- a/types/mypage.ts
+++ b/types/mypage.ts
@@ -52,8 +52,7 @@ export interface PaymentHistory {
 export interface NotificationSettings {
   budgetAlerts: boolean;
   anomalyDetection: boolean;
-  weeklyReport: boolean;
-  monthlyReport: boolean;
+  slackNotifications: boolean;
 }
 
 export interface EmailSettings {
@@ -77,7 +76,6 @@ export interface PrivacySettings {
 
 export interface SettingsState {
   notifications: NotificationSettings;
-  email: EmailSettings;
   preferences: PreferenceSettings;
   privacy: PrivacySettings;
 }


### PR DESCRIPTION
## 개요
설정 페이지를 간소화하고, 토큰 시스템을 Question Unit으로 리브랜딩함. 학생 사용자에게 더 직관적인 용어와 가격 정책을 적용하고, AI 채팅 패널 UX를 개선함.

## 변경 사항
* 설정 페이지 간소화
  - 알림 설정 간소화: 주간/월간 리포트 제거, Slack 알림 추가
  - 이메일 설정 섹션 제거
  - 데이터 관리 섹션 제거
* Question Unit 시스템 도입
  - 토큰(Token) → Question Unit으로 명칭 변경
  - Question Unit 패키지 가격 조정
    - 30 units: ₩4,000
    - 50 units: ₩6,000
    - 100 units: ₩8,000
* UI/UX 개선
  - AI 채팅 패널 너비 확대 (384px → 480px)
  - 레이아웃 여백 조정으로 채팅 패널과 메인 화면 겹침 해소

## 배포
* 프리뷰 배포 성공 (Vercel)
* Question Unit 관련 API 엔드포인트 업데이트 확인 필요

## 참고
* 학생 사용자에게 더 친숙한 "Question Unit" 용어 채택
* 설정 페이지 간소화로 사용자 혼란 감소
* AI 채팅 경험 개선으로 사용성 향상
* 백엔드에서도 토큰 → Question Unit 용어 변경 필요
