### PR TITLE
Fix/24 isNcpSelected 타입 에러 수정

### DIFF
--- a/components/resources/ResourceExplorer.tsx
+++ b/components/resources/ResourceExplorer.tsx
@@ -560,7 +560,7 @@ export function ResourceExplorer() {
                     const isNcpServer = resource.provider === 'NCP' && resource.service === 'Server';
                     // NCP 서버의 경우 첫 번째 활성 계정 사용 (실제로는 백엔드에서 accountId를 포함하도록 수정하는 것이 좋음)
                     const ncpAccountId = isNcpServer && activeNcpAccounts.length > 0 ? activeNcpAccounts[0].id : null;
-                    const isNcpSelected = isNcpServer && selectedNcpInstanceNos.includes(resource.id);
+                    const isNcpSelected = isNcpServer ? selectedNcpInstanceNos.includes(resource.id) : false;
                     
                     return (
                       <tr
@@ -720,7 +720,7 @@ export function ResourceExplorer() {
             const ncpAccountId = resource.provider === 'NCP' && resource.service === 'Server' && activeNcpAccounts.length > 0 
               ? activeNcpAccounts[0].id 
               : null;
-            const isNcpSelected = ncpAccountId && selectedNcpInstanceNos.includes(resource.id);
+            const isNcpSelected = ncpAccountId ? selectedNcpInstanceNos.includes(resource.id) : false;
             
             return (
               <ResourceCard 


### PR DESCRIPTION
### 개요
`isNcpSelected`가 `boolean | 0 | null`로 섞여 들어오며 발생하던 타입 에러를 해결해, 선택 상태 로직의 타입 안정성을 개선했습니다.

### 변경 사항

* `boolean | 0 | null` 값을 **명시적으로 boolean으로 변환**
* `null` 체크를 추가하여 타입 안전성 향상

### 영향 범위

* NCP 선택 여부(`isNcpSelected`)를 사용하는 컴포넌트/로직 1개 파일