### PR TITLE
refactor: NCP 리소스 카드 구조를 다른 클라우드와 통일

### DIFF
--- a/components/resources/ResourceExplorer.tsx
+++ b/components/resources/ResourceExplorer.tsx
@@ -1352,8 +1352,8 @@ function ResourceCard({
             )}
           </>
         )}
-        {((isEc2 && accountId) || isGcpInstance || canShowAzureMetrics) && (
-          <div className="pt-3 border-t border-slate-200">
+        {((isEc2 && accountId) || isGcpInstance || canShowAzureMetrics || isNcpServer) && (
+          <div className="pt-3 border-t border-slate-200 space-y-2">
             <Button
               variant="outline"
               size="sm"
@@ -1365,12 +1365,67 @@ function ResourceCard({
                   setShowGcpMetrics(true);
                 } else if (canShowAzureMetrics) {
                   setShowAzureMetrics(true);
+                } else if (isNcpServer && onNcpMetricsClick) {
+                  onNcpMetricsClick();
                 }
               }}
             >
               <Activity className="mr-2 h-4 w-4" />
               메트릭 보기
             </Button>
+            {isNcpServer && ncpAccountId && (
+              <>
+                <div className="flex items-center gap-2">
+                  {resource.status === 'running' ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="flex-1"
+                      onClick={() => {
+                        if (!confirm(`${resource.name} 서버 인스턴스를 정지하시겠습니까?`)) return;
+                        if (ncpAccountId && onNcpStop) onNcpStop(resource, ncpAccountId);
+                      }}
+                    >
+                      <Square className="mr-2 h-4 w-4" />
+                      정지
+                    </Button>
+                  ) : resource.status === 'stopped' ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="flex-1"
+                      onClick={() => {
+                        if (ncpAccountId && onNcpStart) onNcpStart(resource, ncpAccountId);
+                      }}
+                    >
+                      <Play className="mr-2 h-4 w-4" />
+                      시작
+                    </Button>
+                  ) : null}
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="flex-1"
+                    onClick={() => {
+                      if (ncpAccountId && onNcpTerminate) onNcpTerminate(resource, ncpAccountId);
+                    }}
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" />
+                    삭제
+                  </Button>
+                </div>
+                {onNcpSelectChange && (
+                  <Button
+                    variant={isNcpSelected ? 'default' : 'outline'}
+                    size="sm"
+                    className="w-full"
+                    onClick={() => onNcpSelectChange(!isNcpSelected)}
+                  >
+                    {isNcpSelected ? '집계 대상 해제' : '집계 대상 선택'}
+                  </Button>
+                )}
+              </>
+            )}
           </div>
         )}
       </CardContent>
@@ -1403,68 +1458,6 @@ function ResourceCard({
           displayName={resource.name}
           region={region}
         />
-      )}
-      {isNcpServer && ncpAccountId && (
-        <div className="px-4 pb-4 pt-2 space-y-2">
-          <Button
-            variant="outline"
-            size="sm"
-            className="w-full"
-            onClick={onNcpMetricsClick}
-          >
-            <Activity className="mr-2 h-4 w-4" />
-            메트릭 보기
-          </Button>
-          <div className="flex items-center gap-2">
-            {resource.status === 'running' ? (
-              <Button
-                variant="outline"
-                size="sm"
-                className="flex-1"
-                onClick={() => {
-                  if (!confirm(`${resource.name} 서버 인스턴스를 정지하시겠습니까?`)) return;
-                  if (ncpAccountId && onNcpStop) onNcpStop(resource, ncpAccountId);
-                }}
-              >
-                <Square className="mr-2 h-4 w-4" />
-                정지
-              </Button>
-            ) : resource.status === 'stopped' ? (
-              <Button
-                variant="outline"
-                size="sm"
-                className="flex-1"
-                onClick={() => {
-                  if (ncpAccountId && onNcpStart) onNcpStart(resource, ncpAccountId);
-                }}
-              >
-                <Play className="mr-2 h-4 w-4" />
-                시작
-              </Button>
-            ) : null}
-            <Button
-              variant="outline"
-              size="sm"
-              className="flex-1"
-              onClick={() => {
-                if (ncpAccountId && onNcpTerminate) onNcpTerminate(resource, ncpAccountId);
-              }}
-            >
-              <Trash2 className="mr-2 h-4 w-4" />
-              삭제
-            </Button>
-          </div>
-          {onNcpSelectChange && (
-            <Button
-              variant={isNcpSelected ? 'default' : 'outline'}
-              size="sm"
-              className="w-full"
-              onClick={() => onNcpSelectChange(!isNcpSelected)}
-            >
-              {isNcpSelected ? '집계 대상 해제' : '집계 대상 선택'}
-            </Button>
-          )}
-        </div>
       )}
     </Card>
   );


### PR DESCRIPTION
AWS/GCP/Azure와 동일하게 CardContent 내부에 버튼 배치
- 메트릭 보기, 시작/정지, 삭제 버튼을 CardContent 안으로 이동
- 다른 클라우드 제공자와 일관된 UI 구조 제공